### PR TITLE
activesupport gem was renamed so some fixes are needed

### DIFF
--- a/blueprints.gemspec
+++ b/blueprints.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
   s.require_path = "lib"
 
-  s.add_runtime_dependency(%q<activesupport>, [">= 2.3.0"])
+  s.add_runtime_dependency("activesupport", [">= 2.3.0"])
   s.add_runtime_dependency(%q<database_cleaner>, ["~> 0.6.1"])
   s.add_development_dependency(%q<rspec>, ["~> 2.0"])
   s.add_development_dependency(%q<mysql2>, ["~> 0.2.0"])


### PR DESCRIPTION
I do realise that my fix probably brakes everything for all the older versions of rails, so there must be some conditions or smt to check what's being used or is available. Because all it took is just gem renaming and bundle install started to work again.

Btw it works with pure `gem 'blueprints'`, but failed when I've tried to use `:git => ...` so that's why I've made the change. Maybe that's bundler tricks again, not activesupport ?
